### PR TITLE
Support for -o --output parameter. 

### DIFF
--- a/knockpy/knockpy.py
+++ b/knockpy/knockpy.py
@@ -63,9 +63,9 @@ def statistics():
 	core.header_stats_summary()
 	core.report()
 
-def savescan(domain):
+def savescan(domain, output_file):
 	# Save result
-	core.save_in_csv(domain)
+	core.save_in_csv(domain, output_file)
 
 def getzone(domain):
 	core.getzone(domain)
@@ -101,10 +101,13 @@ The ALIAS name is marked in yellow''')
 	parser.add_argument('-z', '--zone', help='check for zone transfer',
 						action='store_true', required=False)
 
+	parser.add_argument('-o', '--output', help='output file name')
+
 	args = parser.parse_args()
 
 	# args strings
 	domain = args.domain
+	output_file = args.output
 	wlist = args.wordlist
 	if wlist: wlist = wlist[0]
 
@@ -135,7 +138,7 @@ The ALIAS name is marked in yellow''')
 			
 		start(domain)
 		statistics()
-		savescan(domain)
+		savescan(domain, output_file)
 
 	else:
 		exit('error arguments: use knockpy -h to help')

--- a/knockpy/modules/core.py
+++ b/knockpy/modules/core.py
@@ -227,8 +227,8 @@ def report():
 	print target.get_report(targetlist)
 
 # Save result in csv
-def save_in_csv(domain):
-	print target.save_csv(domain)
+def save_in_csv(domain, output_file):
+	print target.save_csv(domain, output_file)
 
 # Zone transfer
 def getzone(domain):

--- a/knockpy/modules/target.py
+++ b/knockpy/modules/target.py
@@ -55,10 +55,14 @@ def get(target, verbose, test):
 
 	return text.rstrip()
 
-def save_csv(domain):
+def save_csv(domain, output_file):
 	if not found: exit()
 	timestamp = utilipy.timestamp()
-	filename = domain.replace('.', '_')+'_'+str(timestamp)+'.csv'
+	if output_file:
+		filename = output_file
+	else:
+		filename = domain.replace('.', '_')+'_'+str(timestamp)+'.csv'
+
 	try:
 		utilipy.touch(filename)
 		with open(filename, 'a') as f:


### PR DESCRIPTION
This parameter allows the user to specify the output file name.

When not specified, the default behavior is triggered, which is generate a random file name, based on timestamp in the end of the scan.

Suggestion for future: -f parameter, to specify a format.

Regards,
Anderson Dadario