### PR TITLE
Added pma (phpMyAdmin) login subdomain

### DIFF
--- a/knockpy/wordlist/wordlist.txt
+++ b/knockpy/wordlist/wordlist.txt
@@ -1323,6 +1323,7 @@ platinum
 pluto
 pm
 pm1
+pma
 pn
 po
 policy


### PR DESCRIPTION
Added `pma` to the wordlist as phpMyAdmin is a somewhat common subdomain for websites using phpMyAdmin. For example, search the following string in Google:

`inurl:https://pma.`

Obviously during the recon phase, finding a phpMyAdmin login would be quite helpful.