### PR TITLE
Update module name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dnspython
+dnspython


### PR DESCRIPTION
The module is called [`dnspython`](https://pypi.org/project/dnspython/). `python-dnspython` is the name the distribution's packages are using.