### PR TITLE
Create the report file at the /tmp filder & print its path

### DIFF
--- a/knockpy/modules/save_report.py
+++ b/knockpy/modules/save_report.py
@@ -9,6 +9,7 @@ def touch(filename):
 def export(domain, report, _type, fields=False):
 	timestamp = time.time()
 	filename = domain.replace('.', '_')+'_'+str(timestamp)+'.'+_type
+	filename = '/tmp/' + filename
 	if _type == 'csv':
 		csv_report = ''
 		if fields:
@@ -20,6 +21,10 @@ def export(domain, report, _type, fields=False):
 		with open(filename, 'a') as f:
 			f.write(report)
 		f.close()
-		return '\n'+_type.upper()+' report saved in: '+filename
-	except: 
-		return '\nCannot write report file: '+filename
+		r='\n'+_type.upper()+' report saved in: '+filename
+		print(str(r))
+		return r
+	except:
+		r='\nCannot write report file: '+filename
+		print(str(r))
+	return r


### PR DESCRIPTION
In order to make parsing tasks easily I need that the report path would be printed. For this reason I modify the save report function to move it to the /tmp folder instead of the current path, as well as printing it. 

I keep the current behaviour so the path will still be part of the error code. Behaviour that I thing that should be removed but I don't know the impact that would have to other users.
