### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
 	},
 	install_requires = [
 			"requests",
-			"bs4",
+			"beautifulsoup4",
 			"colorama"
 			],
 	python_requires=">=3.6",


### PR DESCRIPTION
Don't use [`bs4` dummy package](https://pypi.org/project/bs4/) as distributions don't ship it. They use `beautifulsoup4`.