### PR TITLE
fix bugs

### DIFF
--- a/knockpy/knockpy.py
+++ b/knockpy/knockpy.py
@@ -76,14 +76,20 @@ class Wordlist():
 		dork = "site:%s -site:www.%s" % (domain, domain)
 		url = "https://google.com/search?q=%s&start=%s" % (dork, str(5))
 		params = [domain, url, headers]
-		return Request.bs4scrape(params)
+		try:
+			return Request.bs4scrape(params)
+		except Exception as e:
+			return []
 
 	def duckduckgo(domain):
 		headers = {"user-agent": random.choice(config["user_agent"])}
 		dork = "site:%s -site:www.%s" % (domain, domain)
 		url = "https://duckduckgo.com/html/?q=%s" % dork
 		params = [domain, url, headers]
-		return Request.bs4scrape(params)
+		try:
+			return Request.bs4scrape(params)
+		except Exception as e:
+			return []
 
 	def virustotal(domain, apikey):
 		if not apikey: return []


### PR DESCRIPTION
HTTPSConnectionPool(host='google.com', port=443): Read timed out.
```
Traceback (most recent call last):
  File "knockpy/knockpy.py", line 506, in <module>
    main()
  File "knockpy/knockpy.py", line 429, in main
    local, google, duckduckgo, virustotal = Wordlist.get(domain)
  File "knockpy/knockpy.py", line 113, in get
    google = list(Wordlist.google(domain)) if "google" in config_wordlist["remote"] else []
  File "knockpy/knockpy.py", line 79, in google
    return Request.bs4scrape(params)
  File "knockpy/knockpy.py", line 51, in bs4scrape
    resp = requests.get(url, headers=headers, timeout=config["timeout"])
  File "D:\Python\Python37\lib\site-packages\requests\api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='google.com', port=443): Read timed out. (read timeout=3)
```


Connection to duckduckgo.com timed out.

```
Traceback (most recent call last):
  File "knockpy/knockpy.py", line 502, in <module>
    main()
  File "knockpy/knockpy.py", line 425, in main
    local, google, duckduckgo, virustotal = Wordlist.get(domain)
  File "knockpy/knockpy.py", line 110, in get
    duckduckgo = list(Wordlist.duckduckgo(domain)) if "duckduckgo" in config_wordlist["remote"] else []
  File "knockpy/knockpy.py", line 86, in duckduckgo
    return Request.bs4scrape(params)
  File "knockpy/knockpy.py", line 51, in bs4scrape
    resp = requests.get(url, headers=headers, timeout=config["timeout"])
  File "D:\Python\Python37\lib\site-packages\requests\api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "D:\Python\Python37\lib\site-packages\requests\adapters.py", line 504, in send
    raise ConnectTimeout(e, request=request)
requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='duckduckgo.com', port=443): Max retries exceeded with url: /html/?q=site:r0cky.cn%20-site:www.r0cky.cn (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x000002999DD6EB38>, 'Connection to duckduckgo.com timed out. (connect timeout=3)'))
```