### PR TITLE
added autoaction to upload pypi package on release

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
This PR follows the message that I sent you Gianni. :)

Once merged, you would need to:
* add a secret in the knock repo called PYPI_TOKEN with your pypi token so the action is able to create the pypi repo owned by you
* create a new release
* check whether the actions triggered or not (it should :P)

In this way, it's easier for other projects like [IntelOwl](https://github.com/intelowlproject/IntelOwl) to integrate it as a requirement.

Thank you!