### PR TITLE
check show_report before is_atty

### DIFF
--- a/knock/knockpy.py
+++ b/knock/knockpy.py
@@ -447,8 +447,11 @@ def main():
     #print (args)
     
     if not args.domain and not args.file:
+        if args.report:
+            show_report(args.json, args.report)
+            sys.exit(0)
         # looking for stdin
-        if not sys.stdin.isatty():
+        elif not sys.stdin.isatty():
             stdin = [domain.strip() for domain in sys.stdin.readlines()]
             # can be file or domain
             if len(stdin) == 1:
@@ -464,9 +467,6 @@ def main():
             # cat domains.txt | knockpy
             elif len(stdin) > 1:
                 args.domain = stdin
-        elif args.report:
-            show_report(args.json, args.report)
-            sys.exit(0)
         # no args and not stdin
         # shows help and exit
         else:


### PR DESCRIPTION
In the current state, if arguments `--report /dev/stdin` are passed, the input is read as a list of domains instead of as the JSON output from a previous scan to generate a report.
Moving the check of `args.report` before `checking if stdin is a tty solves the problem.